### PR TITLE
Feat/teste unitario

### DIFF
--- a/src/main/java/dev/odroca/api_provas/controller/UsersController.java
+++ b/src/main/java/dev/odroca/api_provas/controller/UsersController.java
@@ -10,8 +10,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import dev.odroca.api_provas.dto.users.RequestAddRoles;
-import dev.odroca.api_provas.dto.users.ResponseAddRoles;
+import dev.odroca.api_provas.dto.users.RequestAddRole;
+import dev.odroca.api_provas.dto.users.ResponseAddRole;
 import dev.odroca.api_provas.service.UserService;
 
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,9 +25,9 @@ public class UsersController {
     private UserService userService;
 
     @PatchMapping("/role/{userId}")
-    public ResponseEntity<ResponseAddRoles> addRole(@PathVariable UUID userId, @RequestBody RequestAddRoles request) {
-        ResponseAddRoles response = userService.addRole(userId, request);
-        return new ResponseEntity<ResponseAddRoles>(response, HttpStatus.CREATED);
+    public ResponseEntity<ResponseAddRole> addRole(@PathVariable UUID userId, @RequestBody RequestAddRole request) {
+        ResponseAddRole response = userService.addRole(userId, request);
+        return new ResponseEntity<ResponseAddRole>(response, HttpStatus.CREATED);
     }
 
 }

--- a/src/main/java/dev/odroca/api_provas/dto/users/RequestAddRole.java
+++ b/src/main/java/dev/odroca/api_provas/dto/users/RequestAddRole.java
@@ -2,6 +2,6 @@ package dev.odroca.api_provas.dto.users;
 
 import dev.odroca.api_provas.enums.Role;
 
-public record RequestAddRoles(
+public record RequestAddRole(
     Role role
 ) {}

--- a/src/main/java/dev/odroca/api_provas/dto/users/ResponseAddRole.java
+++ b/src/main/java/dev/odroca/api_provas/dto/users/ResponseAddRole.java
@@ -2,7 +2,7 @@ package dev.odroca.api_provas.dto.users;
 
 import java.util.UUID;
 
-public record ResponseAddRoles(
+public record ResponseAddRole(
     UUID userId,
     String message
 ) {}

--- a/src/main/java/dev/odroca/api_provas/service/UserService.java
+++ b/src/main/java/dev/odroca/api_provas/service/UserService.java
@@ -5,8 +5,8 @@ import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import dev.odroca.api_provas.dto.users.RequestAddRoles;
-import dev.odroca.api_provas.dto.users.ResponseAddRoles;
+import dev.odroca.api_provas.dto.users.RequestAddRole;
+import dev.odroca.api_provas.dto.users.ResponseAddRole;
 import dev.odroca.api_provas.entity.UserEntity;
 import dev.odroca.api_provas.exception.UserNotFoundException;
 import dev.odroca.api_provas.repository.UserRepository;
@@ -17,13 +17,13 @@ public class UserService {
     @Autowired
     private UserRepository userRepository;
 
-    public ResponseAddRoles addRole(UUID userId, RequestAddRoles request) {
-        UserEntity user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException());
+    public ResponseAddRole addRole(UUID userId, RequestAddRole request) {
+        UserEntity user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         
         user.setRole(request.role());
 
         userRepository.save(user);
-        return new ResponseAddRoles(userId, "Função do usuário atualizada.");
+        return new ResponseAddRole(userId, "Função do usuário atualizada.");
     }
 
 }

--- a/src/test/java/dev/odroca/api_provas/service/auth/AuthServiceTest.java
+++ b/src/test/java/dev/odroca/api_provas/service/auth/AuthServiceTest.java
@@ -1,0 +1,68 @@
+package dev.odroca.api_provas.service.auth;
+
+import dev.odroca.api_provas.dto.signup.SignupRequestDTO;
+import dev.odroca.api_provas.dto.signup.SignupResponseDTO;
+import dev.odroca.api_provas.entity.UserEntity;
+import dev.odroca.api_provas.exception.EmailAlreadyExistsException;
+import dev.odroca.api_provas.repository.UserRepository;
+import dev.odroca.api_provas.service.AuthService;
+import dev.odroca.api_provas.service.RefreshTokenService;
+import dev.odroca.api_provas.service.utils.UserFactory;
+import dev.odroca.api_provas.utils.CookieUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthServiceTest {
+
+    @InjectMocks
+    AuthService authService;
+
+    @Mock
+    UserRepository userRepository;
+    @Mock
+    RefreshTokenService refreshService;
+    @Mock
+    JwtEncoder jwt;
+    @Mock
+    BCryptPasswordEncoder bcrypt;
+    @Mock
+    CookieUtil cookie;
+
+    @Test
+    @DisplayName("Deve fazer criar uma conta com sucesso")
+    void signupSuccessTest() {
+        SignupRequestDTO request = new SignupRequestDTO("example@example.com", "123@123!abc");
+
+        when(userRepository.findByEmail(request.email())).thenReturn(Optional.empty());
+
+        SignupResponseDTO respose = authService.signup(request);
+        assertEquals("Conta criada com sucesso!", respose.message());
+        verify(userRepository).save(any(UserEntity.class));
+    }
+
+    @Test
+    @DisplayName("Deve retornar EmailAlreadyExistsException quando o usuário já existir")
+    void signupEmailAlreadyExistsExceptionTest() {
+        SignupRequestDTO request = new SignupRequestDTO("example@example.com", "123@123!abc");
+        UserEntity user = UserFactory.buildUserEntity();
+
+        when(userRepository.findByEmail(request.email())).thenReturn(Optional.of(user));
+
+        assertThrows(EmailAlreadyExistsException.class, () -> authService.signup(request));
+    }
+
+}

--- a/src/test/java/dev/odroca/api_provas/service/question/CreateQuestionsTest.java
+++ b/src/test/java/dev/odroca/api_provas/service/question/CreateQuestionsTest.java
@@ -1,9 +1,10 @@
-package dev.odroca.api_provas.service;
+package dev.odroca.api_provas.service.question;
 
 import dev.odroca.api_provas.dto.option.CreateOptionModelDTO;
 import dev.odroca.api_provas.dto.question.CreateQuestionModelDTO;
 import dev.odroca.api_provas.dto.questions.CreateQuestionsRequestDTO;
 import dev.odroca.api_provas.dto.questions.CreateQuestionsResponseDTO;
+import dev.odroca.api_provas.service.QuestionService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/dev/odroca/api_provas/service/question/QuestionServiceTest.java
+++ b/src/test/java/dev/odroca/api_provas/service/question/QuestionServiceTest.java
@@ -1,12 +1,9 @@
-package dev.odroca.api_provas.service;
+package dev.odroca.api_provas.service.question;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -16,12 +13,12 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import dev.odroca.api_provas.exception.*;
+import dev.odroca.api_provas.service.QuestionService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -34,13 +31,11 @@ import dev.odroca.api_provas.dto.question.GetQuestionModelDTO;
 import dev.odroca.api_provas.dto.question.UpdateQuestionRequestDTO;
 import dev.odroca.api_provas.dto.question.UpdateQuestionResponseDTO;
 import dev.odroca.api_provas.dto.questions.CreateQuestionsRequestDTO;
-import dev.odroca.api_provas.dto.questions.CreateQuestionsResponseDTO;
 import dev.odroca.api_provas.entity.OptionEntity;
 import dev.odroca.api_provas.entity.QuestionEntity;
 import dev.odroca.api_provas.entity.TestEntity;
 import dev.odroca.api_provas.mapper.OptionMapper;
 import dev.odroca.api_provas.mapper.QuestionMapper;
-import dev.odroca.api_provas.repository.OptionRepository;
 import dev.odroca.api_provas.repository.QuestionRepository;
 import dev.odroca.api_provas.repository.TestRepository;
 

--- a/src/test/java/dev/odroca/api_provas/service/test/TestServiceTest.java
+++ b/src/test/java/dev/odroca/api_provas/service/test/TestServiceTest.java
@@ -1,6 +1,5 @@
-package dev.odroca.api_provas.service;
+package dev.odroca.api_provas.service.test;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -22,6 +21,9 @@ import dev.odroca.api_provas.exception.InvalidAttributeException;
 import dev.odroca.api_provas.exception.OptionNotFoundException;
 import dev.odroca.api_provas.exception.UnauthorizedException;
 import dev.odroca.api_provas.repository.UserRepository;
+import dev.odroca.api_provas.service.TestService;
+import dev.odroca.api_provas.service.utils.TestFactory;
+import dev.odroca.api_provas.service.utils.UserFactory;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -266,6 +268,17 @@ public class TestServiceTest {
         assertEquals(testEntities.get(0).getId(), response.get(0).getTestId());
         assertEquals(testEntities.get(0).getName(), response.get(0).getName());
         assertEquals(testEntities.get(0).getQuestions().size(), response.get(0).getTotalQuestions());
+    }
+
+    @Test
+    @DisplayName("Deve retornar UnauthorizedException quando não enviar o Access Token")
+    void getAllTestsForUserWithoutAccessTokenTest() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        String randomCookieValue = UUID.randomUUID().toString();
+        request.setCookies(new Cookie("randomCookie", randomCookieValue));
+
+        UUID userId = UUID.fromString("397eec71-360d-4626-805c-6640be635690");
+        assertThrows(UnauthorizedException.class, () -> testService.getAllTestsForUser(userId, request));
     }
 
     @Test

--- a/src/test/java/dev/odroca/api_provas/service/user/UserServiceTest.java
+++ b/src/test/java/dev/odroca/api_provas/service/user/UserServiceTest.java
@@ -1,0 +1,58 @@
+package dev.odroca.api_provas.service.user;
+
+import dev.odroca.api_provas.dto.users.RequestAddRole;
+import dev.odroca.api_provas.dto.users.ResponseAddRole;
+import dev.odroca.api_provas.entity.UserEntity;
+import dev.odroca.api_provas.enums.Role;
+import dev.odroca.api_provas.exception.UserNotFoundException;
+import dev.odroca.api_provas.repository.UserRepository;
+import dev.odroca.api_provas.service.UserService;
+import dev.odroca.api_provas.service.utils.UserFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+    @InjectMocks
+    UserService userService;
+
+    @Mock
+    UserRepository userRepository;
+
+    @Test
+    @DisplayName("Deve adicionar uma role a um usuário")
+    void addRoleSuccessTest() {
+        UUID userId = UUID.fromString("a35a647b-6a7d-4cdc-b92e-87c5be376ee7");
+        UserEntity user = UserFactory.buildUserEntity();
+        RequestAddRole request = new RequestAddRole(Role.MODERATOR);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        ResponseAddRole response = userService.addRole(userId, request);
+
+        verify(userRepository, times(1)).save(user);
+        assertEquals(userId, response.userId());
+        assertEquals("Função do usuário atualizada.", response.message());
+    }
+
+    @Test
+    @DisplayName("Deve retornar UserNotFoundException quando o usuário não existir")
+    void addRoleUserNotFoundExceptionTest() {
+        UUID userId = UUID.fromString("a35a647b-6a7d-4cdc-b92e-87c5be376ee8");
+        RequestAddRole request = new RequestAddRole(Role.MODERATOR);
+
+        assertThrows(UserNotFoundException.class, () -> userService.addRole(userId, request));
+    }
+
+}

--- a/src/test/java/dev/odroca/api_provas/service/utils/OptionFactory.java
+++ b/src/test/java/dev/odroca/api_provas/service/utils/OptionFactory.java
@@ -1,4 +1,4 @@
-package dev.odroca.api_provas.service;
+package dev.odroca.api_provas.service.utils;
 
 import dev.odroca.api_provas.entity.OptionEntity;
 import dev.odroca.api_provas.entity.QuestionEntity;

--- a/src/test/java/dev/odroca/api_provas/service/utils/QuestionFactory.java
+++ b/src/test/java/dev/odroca/api_provas/service/utils/QuestionFactory.java
@@ -1,4 +1,4 @@
-package dev.odroca.api_provas.service;
+package dev.odroca.api_provas.service.utils;
 
 import dev.odroca.api_provas.entity.OptionEntity;
 import dev.odroca.api_provas.entity.QuestionEntity;

--- a/src/test/java/dev/odroca/api_provas/service/utils/TestFactory.java
+++ b/src/test/java/dev/odroca/api_provas/service/utils/TestFactory.java
@@ -1,8 +1,7 @@
-package dev.odroca.api_provas.service;
+package dev.odroca.api_provas.service.utils;
 
 import dev.odroca.api_provas.dto.question.QuestionAnswerModelDTO;
 import dev.odroca.api_provas.dto.test.AnswerTestRequestDTO;
-import dev.odroca.api_provas.dto.test.AnswerTestResponseDTO;
 import dev.odroca.api_provas.entity.OptionEntity;
 import dev.odroca.api_provas.entity.TestEntity;
 import dev.odroca.api_provas.entity.UserEntity;
@@ -12,7 +11,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class TestFactory {
     public static TestEntity buildTestEntity(UserEntity user, UUID testId) {

--- a/src/test/java/dev/odroca/api_provas/service/utils/UserFactory.java
+++ b/src/test/java/dev/odroca/api_provas/service/utils/UserFactory.java
@@ -1,4 +1,4 @@
-package dev.odroca.api_provas.service;
+package dev.odroca.api_provas.service.utils;
 
 import dev.odroca.api_provas.entity.UserEntity;
 import dev.odroca.api_provas.enums.Role;


### PR DESCRIPTION
Faltava testar um branch de acordo com o JaCoCo no camada de serviço de provas (TestService), adicionado o teste `getAllTestsForUserWithoutAccessTokenTest()`.

Comecei os testes na camada de serviço de autorização, adicionado teste de sucesso `signupSuccessTest()` e teste de erro `signupEmailAlreadyExistsExceptionTest()` do método `signup()`.