### PR TITLE
Teste unitario

### DIFF
--- a/src/main/java/dev/odroca/api_provas/entity/RefreshTokenEntity.java
+++ b/src/main/java/dev/odroca/api_provas/entity/RefreshTokenEntity.java
@@ -13,11 +13,13 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Data;
+import lombok.Getter;
 import lombok.Setter;
 
 @Entity
 @Table(name = "refresh_token_table")
-@Data
+@Getter
+@Setter
 public class RefreshTokenEntity {
 
     @Id
@@ -35,5 +37,13 @@ public class RefreshTokenEntity {
     
     @Column(name = "issued_at", nullable = false)
     Instant issuedAt;
-    
+
+    public RefreshTokenEntity() {}
+
+    public RefreshTokenEntity(UserEntity user, Instant expiryDate, Instant issuedAt) {
+        this.user = user;
+        this.expiryDate = expiryDate;
+        this.issuedAt = issuedAt;
+    }
+
 }

--- a/src/test/java/dev/odroca/api_provas/service/auth/AuthServiceTest.java
+++ b/src/test/java/dev/odroca/api_provas/service/auth/AuthServiceTest.java
@@ -4,12 +4,14 @@ import dev.odroca.api_provas.dto.login.LoginRequestDTO;
 import dev.odroca.api_provas.dto.login.LoginResponseDTO;
 import dev.odroca.api_provas.dto.signup.SignupRequestDTO;
 import dev.odroca.api_provas.dto.signup.SignupResponseDTO;
+import dev.odroca.api_provas.entity.RefreshTokenEntity;
 import dev.odroca.api_provas.entity.UserEntity;
 import dev.odroca.api_provas.exception.EmailAlreadyExistsException;
 import dev.odroca.api_provas.exception.InvalidCredentialsException;
 import dev.odroca.api_provas.repository.UserRepository;
 import dev.odroca.api_provas.service.AuthService;
 import dev.odroca.api_provas.service.RefreshTokenService;
+import dev.odroca.api_provas.service.utils.RefreshTokenFactory;
 import dev.odroca.api_provas.service.utils.UserFactory;
 import dev.odroca.api_provas.utils.CookieUtil;
 import org.junit.jupiter.api.DisplayName;
@@ -75,24 +77,25 @@ public class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("")
+    @DisplayName("Deve retornar sucesso ao fazer login pela primeira vez")
     void loginSuccessTest() {
+        UserEntity user = UserFactory.buildUserEntity();
         LoginRequestDTO request = new LoginRequestDTO("example@test.com", "123@123!abc");
         MockHttpServletResponse responseServlet = new MockHttpServletResponse();
-        UserEntity user = UserFactory.buildUserEntity();
+        RefreshTokenEntity refreshToken = RefreshTokenFactory.buildRefreshTokenEntity(user);
 
         Jwt jwtMock = mock(Jwt.class);
+
         when(jwtMock.getTokenValue()).thenReturn("token-falso");
         when(jwt.encode(any(JwtEncoderParameters.class))).thenReturn(jwtMock);
-
-        when(jwt.encode(any(JwtEncoderParameters.class))).thenReturn(jwtMock);
-
         when(userRepository.findByEmail(request.email())).thenReturn(Optional.of(user));
         when(bcrypt.matches(request.password(), user.getPassword())).thenReturn(true);
+        when(refreshService.verifyExistRefreshTokenOfUser(user.getId())).thenReturn(Optional.empty()); // Assumindo que é o primeiro login
+        when(refreshService.createRefreshToken(eq(user), any(Instant.class))).thenReturn(refreshToken);
 
         LoginResponseDTO response = authService.login(request, responseServlet);
 
-        assertEquals("397eec71-360d-4626-805c-6640be635690", response.userId());
+        assertEquals(user.getId().toString(), response.userId());
     }
 
     @Test

--- a/src/test/java/dev/odroca/api_provas/service/auth/AuthServiceTest.java
+++ b/src/test/java/dev/odroca/api_provas/service/auth/AuthServiceTest.java
@@ -1,9 +1,12 @@
 package dev.odroca.api_provas.service.auth;
 
+import dev.odroca.api_provas.dto.login.LoginRequestDTO;
+import dev.odroca.api_provas.dto.login.LoginResponseDTO;
 import dev.odroca.api_provas.dto.signup.SignupRequestDTO;
 import dev.odroca.api_provas.dto.signup.SignupResponseDTO;
 import dev.odroca.api_provas.entity.UserEntity;
 import dev.odroca.api_provas.exception.EmailAlreadyExistsException;
+import dev.odroca.api_provas.exception.InvalidCredentialsException;
 import dev.odroca.api_provas.repository.UserRepository;
 import dev.odroca.api_provas.service.AuthService;
 import dev.odroca.api_provas.service.RefreshTokenService;
@@ -15,15 +18,21 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
 
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class AuthServiceTest {
@@ -45,7 +54,7 @@ public class AuthServiceTest {
     @Test
     @DisplayName("Deve fazer criar uma conta com sucesso")
     void signupSuccessTest() {
-        SignupRequestDTO request = new SignupRequestDTO("example@example.com", "123@123!abc");
+        SignupRequestDTO request = new SignupRequestDTO("example@test.com", "123@123!abc");
 
         when(userRepository.findByEmail(request.email())).thenReturn(Optional.empty());
 
@@ -57,12 +66,57 @@ public class AuthServiceTest {
     @Test
     @DisplayName("Deve retornar EmailAlreadyExistsException quando o usuário já existir")
     void signupEmailAlreadyExistsExceptionTest() {
-        SignupRequestDTO request = new SignupRequestDTO("example@example.com", "123@123!abc");
+        SignupRequestDTO request = new SignupRequestDTO("example@test.com", "123@123!abc");
         UserEntity user = UserFactory.buildUserEntity();
 
         when(userRepository.findByEmail(request.email())).thenReturn(Optional.of(user));
 
         assertThrows(EmailAlreadyExistsException.class, () -> authService.signup(request));
+    }
+
+    @Test
+    @DisplayName("")
+    void loginSuccessTest() {
+        LoginRequestDTO request = new LoginRequestDTO("example@test.com", "123@123!abc");
+        MockHttpServletResponse responseServlet = new MockHttpServletResponse();
+        UserEntity user = UserFactory.buildUserEntity();
+
+        Jwt jwtMock = mock(Jwt.class);
+        when(jwtMock.getTokenValue()).thenReturn("token-falso");
+        when(jwt.encode(any(JwtEncoderParameters.class))).thenReturn(jwtMock);
+
+        when(jwt.encode(any(JwtEncoderParameters.class))).thenReturn(jwtMock);
+
+        when(userRepository.findByEmail(request.email())).thenReturn(Optional.of(user));
+        when(bcrypt.matches(request.password(), user.getPassword())).thenReturn(true);
+
+        LoginResponseDTO response = authService.login(request, responseServlet);
+
+        assertEquals("397eec71-360d-4626-805c-6640be635690", response.userId());
+    }
+
+    @Test
+    @DisplayName("Deve retornar InvalidCredentialsException quando o email não existir")
+    void loginInvalidCredentialsExceptionUserDontExistTest() {
+        LoginRequestDTO request = new LoginRequestDTO("example@teste.com", "123@123!abc");
+        MockHttpServletResponse responseServlet = new MockHttpServletResponse();
+
+        when(userRepository.findByEmail(request.email())).thenReturn(Optional.empty());
+
+        assertThrows(InvalidCredentialsException.class, () -> authService.login(request, responseServlet));
+    }
+
+    @Test
+    @DisplayName("Deve retornar InvalidCredentialsException se as senhas forem incompatíveis")
+    void loginInvalidCredentialsExceptionNoMatchPasswordsTest() {
+        UserEntity user = UserFactory.buildUserEntity();
+        LoginRequestDTO request = new LoginRequestDTO("example@test.com", "123@123!abc");
+        MockHttpServletResponse responseServlet = new MockHttpServletResponse();
+
+        when(userRepository.findByEmail(request.email())).thenReturn(Optional.of(user));
+        when(bcrypt.matches(request.password(), user.getPassword())).thenReturn(false);
+
+        assertThrows(InvalidCredentialsException.class, () -> authService.login(request,responseServlet));
     }
 
 }

--- a/src/test/java/dev/odroca/api_provas/service/utils/RefreshTokenFactory.java
+++ b/src/test/java/dev/odroca/api_provas/service/utils/RefreshTokenFactory.java
@@ -1,0 +1,19 @@
+package dev.odroca.api_provas.service.utils;
+
+import dev.odroca.api_provas.entity.RefreshTokenEntity;
+import dev.odroca.api_provas.entity.UserEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public class RefreshTokenFactory {
+
+    public static RefreshTokenEntity buildRefreshTokenEntity(UserEntity user) {
+        RefreshTokenEntity refreshToken = new RefreshTokenEntity(user, Instant.now().plusSeconds((3600 * 24 * 7)), Instant.now());
+        ReflectionTestUtils.setField(refreshToken, "refreshToken", UUID.fromString("397eec71-360d-4626-805c-6640be635672"));
+
+        return refreshToken;
+    }
+
+}


### PR DESCRIPTION
Adicionado três novos testes, sendo dois de erros para a exceção `InvalidCredentialsException`, um caso o email passado não exista, ou seja, usuário não existe e outro caso senha esteja errada. E um de sucesso.