### PR TITLE
Feat/teste unitario

### DIFF
--- a/src/main/java/dev/odroca/api_provas/service/AuthService.java
+++ b/src/main/java/dev/odroca/api_provas/service/AuthService.java
@@ -84,9 +84,7 @@ public class AuthService {
 
         Optional<RefreshTokenEntity> existingRefreshToken = refreshService.verifyExistRefreshTokenOfUser(user.getId());
 
-        if (existingRefreshToken.isPresent()) {
-            refreshService.deleteRefreshToken(existingRefreshToken.get().getRefreshToken());
-        }
+        existingRefreshToken.ifPresent(refreshTokenEntity -> refreshService.deleteRefreshToken(refreshTokenEntity.getRefreshToken()));
 
         RefreshTokenEntity refreshToken = refreshService.createRefreshToken(user, Instant.now().plusSeconds(refreshTokenExpireIn));
 

--- a/src/test/java/dev/odroca/api_provas/service/auth/AuthServiceTest.java
+++ b/src/test/java/dev/odroca/api_provas/service/auth/AuthServiceTest.java
@@ -77,6 +77,28 @@ public class AuthServiceTest {
     }
 
     @Test
+    @DisplayName("Deve retornar sucesso ao fazer login")
+    void loginFirstTimeSuccessTest() {
+        UserEntity user = UserFactory.buildUserEntity();
+        LoginRequestDTO request = new LoginRequestDTO("example@test.com", "123@123!abc");
+        MockHttpServletResponse responseServlet = new MockHttpServletResponse();
+        RefreshTokenEntity refreshTokenEntity = RefreshTokenFactory.buildRefreshTokenEntity(user);
+
+        Jwt jwtMock = mock(Jwt.class);
+
+        when(jwtMock.getTokenValue()).thenReturn("token-falso");
+        when(jwt.encode(any(JwtEncoderParameters.class))).thenReturn(jwtMock);
+        when(userRepository.findByEmail(request.email())).thenReturn(Optional.of(user));
+        when(bcrypt.matches(request.password(), user.getPassword())).thenReturn(true);
+        when(refreshService.verifyExistRefreshTokenOfUser(user.getId())).thenReturn(Optional.of(refreshTokenEntity)); // Assumindo que já fez o primeiro login
+        when(refreshService.createRefreshToken(eq(user), any(Instant.class))).thenReturn(refreshTokenEntity);
+
+        LoginResponseDTO response = authService.login(request, responseServlet);
+
+        assertEquals(user.getId().toString(), response.userId());
+    }
+
+    @Test
     @DisplayName("Deve retornar sucesso ao fazer login pela primeira vez")
     void loginSuccessTest() {
         UserEntity user = UserFactory.buildUserEntity();

--- a/src/test/java/dev/odroca/api_provas/service/auth/AuthServiceTest.java
+++ b/src/test/java/dev/odroca/api_provas/service/auth/AuthServiceTest.java
@@ -23,14 +23,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.jwt.JwtClaimsSet;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
 
 import java.time.Instant;
-import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -49,9 +46,9 @@ public class AuthServiceTest {
     @Mock
     JwtEncoder jwt;
     @Mock
-    BCryptPasswordEncoder bcrypt;
-    @Mock
     CookieUtil cookie;
+    @Mock
+    BCryptPasswordEncoder bcrypt;
 
     @Test
     @DisplayName("Deve fazer criar uma conta com sucesso")

--- a/src/test/java/dev/odroca/api_provas/service/refresh/RefreshTokenServiceTest.java
+++ b/src/test/java/dev/odroca/api_provas/service/refresh/RefreshTokenServiceTest.java
@@ -1,0 +1,66 @@
+package dev.odroca.api_provas.service.refresh;
+
+import dev.odroca.api_provas.entity.RefreshTokenEntity;
+import dev.odroca.api_provas.entity.UserEntity;
+import dev.odroca.api_provas.repository.RefreshTokenRepository;
+import dev.odroca.api_provas.service.RefreshTokenService;
+import dev.odroca.api_provas.service.utils.RefreshTokenFactory;
+import dev.odroca.api_provas.service.utils.UserFactory;
+import dev.odroca.api_provas.utils.CookieUtil;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class RefreshTokenServiceTest {
+
+    @InjectMocks
+    RefreshTokenService refreshService;
+
+    @Mock
+    RefreshTokenRepository refreshRepository;
+    @Mock
+    JwtEncoder jwt;
+    @Mock
+    CookieUtil cookie;
+
+    @Test
+    @DisplayName("Deve retornar sucesso ao gerar um novo par tokens")
+    void refreshSuccess() {
+        UserEntity user = UserFactory.buildUserEntity();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        Cookie refreshToken = new Cookie("refreshToken", "1c465b2a-f088-48a6-a20f-cb54b3d4f571");
+        request.setCookies(refreshToken);
+
+        RefreshTokenEntity refreshTokenEntity = RefreshTokenFactory.buildRefreshTokenEntity(user);
+        Jwt jwtMocked = mock(Jwt.class);
+        String fakeAccessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.KMUFsIDTnFmyG3nMiGM6H9FNFUROf3wh7SmqJp-QV30";
+
+        when(jwtMocked.getTokenValue()).thenReturn(fakeAccessToken);
+        when(jwt.encode(any())).thenReturn(jwtMocked);
+        when(refreshRepository.save(any())).thenReturn(RefreshTokenFactory.buildRefreshTokenEntity(user)); // retorno do createRefreshToken
+        when(refreshRepository.findByRefreshToken(UUID.fromString(refreshToken.getValue()))).thenReturn(Optional.of(refreshTokenEntity));
+
+        refreshService.refresh(request, response);
+    }
+
+}


### PR DESCRIPTION
Adicionado testes novos. Sendo teste login ao após já ter feito login pela primeira vez, ou seja, já existe um refresh token no banco de dados. Teste de sucesso ao precisar de utilizar o refresh token, gerando um par de chaves novas, refresh e access token.